### PR TITLE
Request Params Restructure

### DIFF
--- a/previewImage.html
+++ b/previewImage.html
@@ -57,10 +57,10 @@
   <body>
     <div class="wrap">
       <div class="center">
-        <p id="defund">Defund12.org <br><span style="font-size: 45px; font-weight: 300;">in {{city}}, {{state}}</span></p>
-        <p class="officials">{{text}}</p>
+        <p id="defund">{{header}}<br><span style="font-size: 45px; font-weight: 300;">{{subheader}}</span></p>
+        <p class="officials">{{subtitle1}}</p>
         <p class="desc" style="width: 1000px">
-          Demand they reallocate egregious police budgets towards education, social services, and dismantling racial inequality.
+          {{subtitle2}}
         </p>
       </div>
     </div>

--- a/previews.js
+++ b/previews.js
@@ -14,71 +14,28 @@ Visit http://localhost:5000`);
 
 const previewTemplate = fs.readFileSync(path.resolve(__dirname, "previewImage.html"), "utf8");
 
-//deprecated - remove after succesful usage of other api route
-app.get("/api/preview", async (req, res) => {
-  if (!req.query.city) {
-    res.status(400).send("You need to specify city");
-  }
+let defaultTemplateStrings = {
+  'header':"Defund12.org",
+  'subheader':"", 
+  'subtitle1':"Send pre-scripted emails and physical letters to government officials and council members.", 
+  'subtitle2':"Demand they reallocate egregious police budgets towards education, social services, and dismantling racial inequality."
+}
 
-  if (!req.query.state) {
-    res.status(400).send("You need to specify state");
-  }
-
-  const { city, state } = req.query;
-
-  const text = `Send pre-scripted emails to ${city} government officials.`
-
-  // Support linew breaks
-  const formattedCity = city.replace(/(?:\r\n|\r|\n)/g, "<br>");
+app.get("/api/preview*", async (req, res) => {
+  let template = {...defaultTemplateStrings}
+  Object.keys(template).forEach((field)=>{
+    if(req.query[field]){
+      template[field]=req.query[field]
+    }
+  })
 
   const image = await getImage({
     // output: "./image.png",
 
-    content: {city: formattedCity, state, text},
+    content: template,
     html : previewTemplate,
   });
-
 
   res.writeHead(200, { "Content-Type": "image/png" });
   res.end(image, "binary");
 });
-
-app.get("/api/preview/:type", async (req, res) => {
-  if (!req.query.city) {
-    res.status(400).send("You need to specify city");
-  }
-
-  if (!req.query.state) {
-    res.status(400).send("You need to specify state");
-  }
-
-  const { city, state } = req.query;
-
-  
-  let text;
-  switch(req.params.type) {
-    case "letter": 
-      text = `Order physical letters to be printed and mailed to ${city} government officials.`
-      break;
-    case "email":
-      text = `Send pre-scripted emails to ${city} government officials.`
-      break;
-    default:
-      text = "Send pre-scripted emails to government officials"
-  }
-
-  // Support linew breaks
-  const formattedCity = city.replace(/(?:\r\n|\r|\n)/g, "<br>");
-
-  const image = await getImage({
-    // output: "./image.png",
-
-    content: {city: formattedCity, state, text},
-    html : previewTemplate,
-  });
-
-
-  res.writeHead(200, { "Content-Type": "image/png" });
-  res.end(image, "binary");
-});
-


### PR DESCRIPTION
instead of accepting field like layout, city, and state, which are then used in string templates to fill out the image template, now the strings to fill out image template are directly passed in through the request through query params. this allows for more fluid manipulation of previews from the frontend without having to make api changes